### PR TITLE
HOCS-1925

### DIFF
--- a/kd/deployment.yaml
+++ b/kd/deployment.yaml
@@ -198,10 +198,10 @@ spec:
                   key: url
           resources:
             limits:
-              cpu: 900m
-              memory: 1024Mi
+              cpu: 1200m
+              memory: 1536Mi
             requests:
-              cpu: 100m
+              cpu: 200m
               memory: 512Mi
           ports:
             - name: http


### PR DESCRIPTION
The new DCU data has caused the system to hit memory and cpu usage limits (lots of recycling on the services and also errors on the automated tests).
This service is one of many to be changed so that the system is able to handle the new data volume.